### PR TITLE
A-1206698645024316: get balance from api instead of utxo

### DIFF
--- a/.env
+++ b/.env
@@ -1,6 +1,6 @@
 REACT_APP_CONFIG_NAME=default
 REACT_APP_WEBSITE_NAME=Mojito - A Mintlayer Wallet (default)
-INLINE_RUNTIME_CHUNK=false 
+INLINE_RUNTIME_CHUNK=false
 GENERATE_SOURCEMAP=false
 MAINNET_ELECTRUM_SERVERS='https://blockstream.info/api'
 TESTNET_ELECTRUM_SERVERS='http://51.158.172.176:3001, https://blockstream.info/testnet/api'

--- a/src/components/composed/Balance/Balance.css
+++ b/src/components/composed/Balance/Balance.css
@@ -18,7 +18,7 @@
   margin-left: 17px;
   position: relative;
   overflow: visible;
-  width: 200px;
+  width: 265px;
 }
 
 .balance-btc {

--- a/src/components/composed/Balance/Balance.css
+++ b/src/components/composed/Balance/Balance.css
@@ -18,6 +18,7 @@
   margin-left: 17px;
   position: relative;
   overflow: visible;
+  width: 200px;
 }
 
 .balance-btc {

--- a/src/services/API/Mintlayer/Mintlayer.js
+++ b/src/services/API/Mintlayer/Mintlayer.js
@@ -82,10 +82,16 @@ const getAddressBalance = async (address) => {
     const balance = {
       balanceInAtoms: data.coin_balance,
     }
-    return balance
+    const balanceLocked = {
+      balanceInAtoms: data.locked_coin_balance || 0,
+    }
+    return { balance, balanceLocked }
   } catch (error) {
     console.warn(`Failed to get balance for address ${address}: `, error)
-    return { balanceInAtoms: 0 }
+    return {
+      balance: { balanceInAtoms: 0 },
+      balanceLocked: { balanceInAtoms: 0 },
+    }
   }
 }
 
@@ -96,12 +102,22 @@ export const getWalletBalance = async (addresses) => {
     (acc, curr) => {
       return {
         balanceInAtoms:
-          +parseInt(acc.balanceInAtoms) + parseInt(curr.balanceInAtoms),
+          +parseInt(acc.balanceInAtoms) + parseInt(curr.balance.balanceInAtoms),
       }
     },
     { balanceInAtoms: 0 },
   )
-  return totalBalance
+  const lockedBalance = balances.reduce(
+    (acc, curr) => {
+      return {
+        balanceInAtoms:
+          +parseInt(acc.balanceInAtoms) +
+          parseInt(curr.balanceLocked.balanceInAtoms),
+      }
+    },
+    { balanceInAtoms: 0 },
+  )
+  return { totalBalance, lockedBalance }
 }
 
 const getAddressTransactionIds = async (address) => {

--- a/src/services/API/Mintlayer/Mintlayer.test.js
+++ b/src/services/API/Mintlayer/Mintlayer.test.js
@@ -95,5 +95,5 @@ test('Mintlayer API request - getAdressTransactions', async () => {
 
 test('Mintlayer API request - getAddressBalance', async () => {
   const result = await getAddressBalance(TESTNET_WALLET)
-  expect(Number(result.balanceInAtoms)).toBeGreaterThan(0)
+  expect(Number(result.balance.balanceInAtoms)).toBeGreaterThan(0)
 })

--- a/src/utils/Helpers/ML/MLTransaction.js
+++ b/src/utils/Helpers/ML/MLTransaction.js
@@ -13,14 +13,7 @@ const getUtxoAvailable = (utxo) => {
   const available = utxo
     .flatMap((utxo) => [...utxo])
     .reduce((acc, item) => {
-      if (item.utxo.type === 'Transfer') {
-        acc.push(item)
-      }
-      if (item.utxo.type === 'LockThenTransfer') {
-        if (item.utxo.lock.UntilTime.timestamp < Date.now() / 1000) {
-          acc.push(item)
-        }
-      }
+      acc.push(item)
       return acc
     }, [])
 


### PR DESCRIPTION
# :speech_balloon: Description 

- Revert utxo filtering
- Locked balance from API 

# :clipboard: Checklist:

- [x] I have named my branch as `A-[id of Asana task]`
- [x] I have set the title of my PR as `A-[id of Asana task]: [short description]`
- [x] My changes passed successfully by `prettier` check
- [x] My changes passed successfully by `lint` check
- [x] My changes kept the previous test coverage rate
- [x] I have added enough tests for my new feature/bugfix
- [x] I have set at least one person to review this PR
- [x] I have set myself as the assignee of this PR
- [x] I have set at least one label to this PR