### PR TITLE
A-1209904415584932: reduct network calls fix logout on switch network to fetch proper set of addresses

### DIFF
--- a/src/components/containers/Settings/SettingsTestnet/SettingsTestnet.js
+++ b/src/components/containers/Settings/SettingsTestnet/SettingsTestnet.js
@@ -1,18 +1,24 @@
 import { useContext } from 'react'
 import { Toggle } from '@BasicComponents'
-import { MintlayerContext, SettingsContext } from '@Contexts'
+import { AccountContext, MintlayerContext, SettingsContext } from '@Contexts'
 import { VerticalGroup } from '@LayoutComponents'
 import { AppInfo } from '@Constants'
 
 import './SettingsTestnet.css'
+import { useNavigate } from 'react-router-dom'
 
 const SettingsTestnet = () => {
   const { networkType, toggleNetworkType } = useContext(SettingsContext)
+  const { logout } = useContext(AccountContext)
+  const navigate = useNavigate()
   const { setAllDataFetching } = useContext(MintlayerContext)
   const isTestnetEnabled = networkType === AppInfo.NETWORK_TYPES.TESTNET
   const onToggle = () => {
     setAllDataFetching(false)
     toggleNetworkType()
+
+    logout()
+    navigate('/')
   }
   return (
     <div
@@ -25,6 +31,9 @@ const SettingsTestnet = () => {
           <p>
             With Testnet mode, you can test transactions without the need for
             actual coins. This is useful for testing purposes.
+          </p>
+          <p>
+            <b>NOTE</b>: When you switch network mode, you need to login again
           </p>
         </VerticalGroup>
       </div>

--- a/src/services/Entity/Account/Account.js
+++ b/src/services/Entity/Account/Account.js
@@ -5,6 +5,7 @@ import { AppInfo } from '@Constants'
 import { getEncryptedPrivateKeys } from './AccountHelpers'
 
 import loadAccountSubRoutines from './loadWorkers'
+import { LocalStorageService } from '@Storage'
 
 const saveAccount = async (data) => {
   const { generateEncryptionKey } = await loadAccountSubRoutines()
@@ -79,6 +80,8 @@ const unlockAccount = async (id, password) => {
   const mainnetNetwork = bitcoin.networks['bitcoin']
   const testnetNetwork = bitcoin.networks['testnet']
 
+  const storedNetworkType = LocalStorageService.getItem('networkType')
+
   const { generateEncryptionKey, decryptSeed } = await loadAccountSubRoutines()
   const addresses = {}
 
@@ -133,19 +136,24 @@ const unlockAccount = async (id, password) => {
     }
 
     if (walletsToCreate.includes('ml')) {
-      const mlTestnetWalletAddresses = await ML.getWalletAddresses(
-        mlTestnetPrivateKey,
-        AppInfo.NETWORK_TYPES.TESTNET,
-        AppInfo.DEFAULT_ML_WALLET_OFFSET,
-      )
-      addresses.mlTestnetAddresses = mlTestnetWalletAddresses
+      // TODO: use only network-related addresses
+      if (storedNetworkType === 'testnet') {
+        const mlTestnetWalletAddresses = await ML.getWalletAddresses(
+          mlTestnetPrivateKey,
+          AppInfo.NETWORK_TYPES.TESTNET,
+          AppInfo.DEFAULT_ML_WALLET_OFFSET,
+        )
+        addresses.mlTestnetAddresses = mlTestnetWalletAddresses
+      }
 
-      const mlMainnetWalletAddresses = await ML.getWalletAddresses(
-        mlMainnetPrivateKey,
-        AppInfo.NETWORK_TYPES.MAINNET,
-        AppInfo.DEFAULT_ML_WALLET_OFFSET,
-      )
-      addresses.mlMainnetAddresses = mlMainnetWalletAddresses
+      if (storedNetworkType === 'mainnet') {
+        const mlMainnetWalletAddresses = await ML.getWalletAddresses(
+          mlMainnetPrivateKey,
+          AppInfo.NETWORK_TYPES.MAINNET,
+          AppInfo.DEFAULT_ML_WALLET_OFFSET,
+        )
+        addresses.mlMainnetAddresses = mlMainnetWalletAddresses
+      }
     }
 
     return {

--- a/src/services/Entity/Account/Account.js
+++ b/src/services/Entity/Account/Account.js
@@ -5,7 +5,6 @@ import { AppInfo } from '@Constants'
 import { getEncryptedPrivateKeys } from './AccountHelpers'
 
 import loadAccountSubRoutines from './loadWorkers'
-import { LocalStorageService } from '@Storage'
 
 const saveAccount = async (data) => {
   const { generateEncryptionKey } = await loadAccountSubRoutines()
@@ -80,8 +79,6 @@ const unlockAccount = async (id, password) => {
   const mainnetNetwork = bitcoin.networks['bitcoin']
   const testnetNetwork = bitcoin.networks['testnet']
 
-  const storedNetworkType = LocalStorageService.getItem('networkType')
-
   const { generateEncryptionKey, decryptSeed } = await loadAccountSubRoutines()
   const addresses = {}
 
@@ -136,24 +133,19 @@ const unlockAccount = async (id, password) => {
     }
 
     if (walletsToCreate.includes('ml')) {
-      // TODO: use only network-related addresses
-      if (storedNetworkType === 'testnet') {
-        const mlTestnetWalletAddresses = await ML.getWalletAddresses(
-          mlTestnetPrivateKey,
-          AppInfo.NETWORK_TYPES.TESTNET,
-          AppInfo.DEFAULT_ML_WALLET_OFFSET,
-        )
-        addresses.mlTestnetAddresses = mlTestnetWalletAddresses
-      }
+      const mlTestnetWalletAddresses = await ML.getWalletAddresses(
+        mlTestnetPrivateKey,
+        AppInfo.NETWORK_TYPES.TESTNET,
+        AppInfo.DEFAULT_ML_WALLET_OFFSET,
+      )
+      addresses.mlTestnetAddresses = mlTestnetWalletAddresses
 
-      if (storedNetworkType === 'mainnet') {
-        const mlMainnetWalletAddresses = await ML.getWalletAddresses(
-          mlMainnetPrivateKey,
-          AppInfo.NETWORK_TYPES.MAINNET,
-          AppInfo.DEFAULT_ML_WALLET_OFFSET,
-        )
-        addresses.mlMainnetAddresses = mlMainnetWalletAddresses
-      }
+      const mlMainnetWalletAddresses = await ML.getWalletAddresses(
+        mlMainnetPrivateKey,
+        AppInfo.NETWORK_TYPES.MAINNET,
+        AppInfo.DEFAULT_ML_WALLET_OFFSET,
+      )
+      addresses.mlMainnetAddresses = mlMainnetWalletAddresses
     }
 
     return {


### PR DESCRIPTION
# :speech_balloon: Description 

When network switched addresses new new network are not generated but not happens wallet unlock. Solution is logout when network changed. Better solution coming in next PR. Idea is to generate addresses in a front, but do network calls only for selected network

<img width="801" alt="Screenshot 2025-04-25 at 09 53 14" src="https://github.com/user-attachments/assets/db93c2a9-df9f-45a1-8546-7b33d16c6f8b" />


### More

**[If needed]** List here other this you've done in this PR. Eg.:

- Refactoring user validation to improve code readability
- Improving account creation tests to verify if the password set is strong enough


# :camera: Screenshots

**[If needed]** List here how the component/screen/behavior should look like in the design and how it is being rendered. You can list different screenshots for states of that component/screen/behavior. Animated GIFs can be used if needed!


# :clipboard: Checklist:

- [x] I have named my branch as `A-[id of Asana task]`
- [x] I have set the title of my PR as `A-[id of Asana task]: [short description]`
- [x] My changes passed successfully by `prettier` check
- [x] My changes passed successfully by `lint` check
- [x] My changes kept the previous test coverage rate
- [x] I have added enough tests for my new feature/bugfix
- [x] I have set at least one person to review this PR
- [x] I have set myself as the assignee of this PR
- [x] I have set at least one label to this PR